### PR TITLE
Score comfirmation update

### DIFF
--- a/frontend_scoring/src/QueryHooks/types/Competition.ts
+++ b/frontend_scoring/src/QueryHooks/types/Competition.ts
@@ -1,0 +1,46 @@
+export interface Competition {
+  id: number;
+  title: string;
+  sub_title: string;
+  start_time: string;
+  end_time: string;
+  host_id: number;
+  rounds_num: number;
+  unassigned_group_id: number;
+  groups_num: number;
+  unassigned_lane_id: number;
+  lanes_num: number;
+  current_phase: number;
+  qualification_current_end: number;
+  qualification_is_active: boolean;
+  elimination_is_active: boolean;
+  team_elimination_is_active: boolean;
+  mixed_elimination_is_active: boolean;
+  script: string;
+  groups?: Group[];
+  participants?: null;
+}
+
+export interface Group {
+  id: number;
+  competition_id: number;
+  group_name: string;
+  group_range: string;
+  bow_type: string;
+  group_index: number;
+  players: Player[];
+}
+
+export interface Player {
+  id: number;
+  group_id: number;
+  lane_id: number;
+  participant_id: number;
+  name: string;
+  total_score: number;
+  shoot_off_score: number;
+  rank: number;
+  order: number;
+  rounds: null;
+  player_sets: null;
+}

--- a/frontend_scoring/src/QueryHooks/types/Lane.ts
+++ b/frontend_scoring/src/QueryHooks/types/Lane.ts
@@ -1,0 +1,41 @@
+export interface Lane {
+  id: number;
+  competition_id: number;
+  qualification_id: number;
+  lane_number: number;
+  players: Player[];
+}
+
+export interface Player {
+  id: number;
+  group_id: number;
+  lane_id: number;
+  participant_id: number;
+  name: string;
+  total_score: number;
+  shoot_off_score: number;
+  rank: number;
+  order: number;
+  rounds: Round[];
+  player_sets: null;
+}
+
+export interface Round {
+  id: number;
+  player_id: number;
+  total_score: number;
+  round_ends: RoundEnd[];
+}
+
+export interface RoundEnd {
+  id: number;
+  round_id: number;
+  is_confirmed: boolean;
+  round_scores: RoundScore[];
+}
+
+export interface RoundScore {
+  id: number;
+  round_end_id: number;
+  score: number;
+}

--- a/frontend_scoring/src/QueryHooks/useGetCompetition.tsx
+++ b/frontend_scoring/src/QueryHooks/useGetCompetition.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "react-query";
 import axios from "axios";
+import { Competition } from "./types/Competition";
 
 export default function useGetCompetition(competitionID: number) {
   return useQuery(
@@ -9,7 +10,7 @@ export default function useGetCompetition(competitionID: number) {
       staleTime: 2000,
       select: (data: any) => {
         const competition = data?.data;
-        return competition as any;
+        return competition as Competition;
       },
     }
   );

--- a/frontend_scoring/src/QueryHooks/useGetGroupsWithPlayers.tsx
+++ b/frontend_scoring/src/QueryHooks/useGetGroupsWithPlayers.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "react-query";
 import axios from "axios";
+import { Group } from "./types/Competition";
 
 export default function useGetGroupsWithPlayers(competitionID: number) {
   return useQuery(
@@ -9,7 +10,7 @@ export default function useGetGroupsWithPlayers(competitionID: number) {
       staleTime: 2000,
       select: (data: any) => {
         const groups = data?.data.groups;
-        return groups as any;
+        return groups as Group[];
       },
     }
   );

--- a/frontend_scoring/src/QueryHooks/useGetLaneWithPlayersScores.tsx
+++ b/frontend_scoring/src/QueryHooks/useGetLaneWithPlayersScores.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "react-query";
 import axios from "axios";
+import { Lane } from "./types/Lane";
 
 export default function useGetLaneWithPlayersScores(laneID: number) {
   return useQuery(
@@ -9,7 +10,7 @@ export default function useGetLaneWithPlayersScores(laneID: number) {
       staleTime: 2000,
       select: (data: any) => {
         const lane = data?.data;
-        return lane as any;
+        return lane as Lane;
       },
     }
   );

--- a/frontend_scoring/src/QueryHooks/useGetLanes.tsx
+++ b/frontend_scoring/src/QueryHooks/useGetLanes.tsx
@@ -1,12 +1,13 @@
 import { useQuery } from "react-query";
 import axios from "axios";
+import { Lane } from "./types/Lane";
 
 export default function useGetLanes(competitionID: number) {
   return useQuery("lanes", () => axios.get(`/api/lane/all/${competitionID}`), {
     staleTime: 30000,
     select: (data: any) => {
       const lanes = data?.data;
-      return lanes as any;
+      return lanes as Lane[];
     },
   });
 }

--- a/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/OverviewBlock/OverviewBlock.tsx
+++ b/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/OverviewBlock/OverviewBlock.tsx
@@ -5,8 +5,8 @@ import { useSelector } from "react-redux";
 
 export default function OverviewBlock() {
   const competitionID = useSelector((state: any) => state.game.competitionID);
-  const { data: competition, isLoading } = useGetCompetition(competitionID);
-  if (isLoading) return <></>;
+  const { data: competition } = useGetCompetition(competitionID);
+  if (!competition) return <></>;
 
   const currentEnd = competition.qualification_current_end;
 

--- a/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/PlayerStatusBlock/LaneBlock.tsx
+++ b/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/PlayerStatusBlock/LaneBlock.tsx
@@ -9,12 +9,9 @@ interface Props {
 
 export default function LaneBlock({ laneShell }: Props) {
   const competitionID = useSelector((state: any) => state.game.competitionID);
-  const { data: lane, isLoading: isLoadingLane } = useGetLaneWithPlayersScores(
-    laneShell.id
-  );
-  const { data: competition, isLoading: isLoadingCompetition } =
-    useGetCompetition(competitionID);
-  if (isLoadingLane || isLoadingCompetition) {
+  const { data: lane } = useGetLaneWithPlayersScores(laneShell.id);
+  const { data: competition } = useGetCompetition(competitionID);
+  if (!lane || !competition) {
     return <></>;
   }
   const currentEnd: number = competition.qualification_current_end;
@@ -30,9 +27,11 @@ export default function LaneBlock({ laneShell }: Props) {
 
       playerLights.push(
         <PlayerLight
-          laneIndex={lane?.lane_number}
+          laneIndex={lane.lane_number}
           order={player.order}
-          isConfirmed={round?.round_ends[endIndex].is_confirmed}
+          isConfirmed={round.round_ends[endIndex].is_confirmed}
+          roundEndId={round.round_ends[endIndex].id}
+          laneId={lane.id}
         ></PlayerLight>
       );
     }

--- a/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/PlayerStatusBlock/PlayerLight.tsx
+++ b/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/PlayerStatusBlock/PlayerLight.tsx
@@ -1,13 +1,34 @@
 import { Avatar } from "@mui/material";
-
+import { useQueryClient, useMutation } from "react-query";
+import axios from "axios";
+const putIsConfirmed = ({ roundEndId, isConfirmed }: any) => {
+  return axios.put(`/api/player/isconfirmed/${roundEndId}`, {
+    is_confirmed: !isConfirmed,
+  });
+};
 interface Props {
   laneIndex: number;
   order: number;
   isConfirmed: boolean;
+  roundEndId: number;
+  laneId: number;
 }
 
-export default function PlayerLight({ laneIndex, order, isConfirmed }: Props) {
+export default function PlayerLight({
+  laneIndex,
+  order,
+  isConfirmed,
+  roundEndId,
+  laneId,
+}: Props) {
   let playerCode = laneIndex.toString();
+  const queryClient = useQueryClient();
+
+  const { mutate: toggleConfirmation } = useMutation(putIsConfirmed, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["laneWithPlayersScores", laneId]);
+    },
+  });
 
   playerCode += String.fromCharCode("A".charCodeAt(0) + order - 1);
 
@@ -19,6 +40,12 @@ export default function PlayerLight({ laneIndex, order, isConfirmed }: Props) {
         fontSize: "12px",
         backgroundColor: isConfirmed ? "#1bdc1b" : "#dc1b1b",
         color: "white",
+      }}
+      onClick={() => {
+        toggleConfirmation({
+          roundEndId: roundEndId,
+          isConfirmed: isConfirmed,
+        });
       }}
     >
       {playerCode}

--- a/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/PlayerStatusBlock/PlayerStatusBlock.tsx
+++ b/frontend_scoring/src/features/AdministrationBoard/ProgressBoard/Qualification/PlayerStatusBlock/PlayerStatusBlock.tsx
@@ -5,9 +5,9 @@ import { useSelector } from "react-redux";
 
 export default function PlayerStatusBlock() {
   const competitionID = useSelector((state: any) => state.game.competitionID);
-  const { data: lanes, isLoading: isLoadingLanes } = useGetLanes(competitionID);
+  const { data: lanes } = useGetLanes(competitionID);
 
-  if (isLoadingLanes) {
+  if (!lanes) {
     return <></>;
   }
   let items = [];

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/LaneBoard.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/LaneBoard.tsx
@@ -30,7 +30,8 @@ export default function LaneBoard() {
     isLoadingGroups ||
     isLoadingLane ||
     isLoadingCompetition ||
-    player === undefined
+    player === undefined ||
+    lane === undefined
   )
     return <></>;
 
@@ -41,6 +42,7 @@ export default function LaneBoard() {
   let playerInfos = [];
   for (let i = 0; i < lane.players.length; i++) {
     const player = lane.players[i];
+    if (player === undefined) continue;
     playerInfos.push(
       <ToggleButton value={player.id} key={i} className="player_button">
         <PlayerInfoBar player={player}></PlayerInfoBar>

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/LaneBoard.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/LaneBoard.tsx
@@ -60,10 +60,8 @@ export default function LaneBoard() {
         {playerInfos}
       </ToggleButtonGroup>
       <ScoreController
-        player={lane.players.find((p: any) => p.id === player.id)}
-        selectedPlayer={lane.players.find(
-          (p: any) => p.id === selectedPlayerID
-        )}
+        player={lane.players.find((p) => p.id === player.id)}
+        selectedPlayer={lane.players.find((p) => p.id === selectedPlayerID)}
         possibleScores={[11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]} // TODO: get possible scores from "server"
       ></ScoreController>
     </div>

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/LaneBoard.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/LaneBoard.tsx
@@ -9,30 +9,21 @@ import TargetSigns from "./TargetSigns";
 import { setSelectedPlayerID } from "./ScoreController/scoreControllerSlice";
 import useGetCompetition from "../../../QueryHooks/useGetCompetition";
 import PreQualificationNote from "./PreQualificationNote";
+import { Group } from "../../../QueryHooks/types/Competition";
 
 export default function LaneBoard() {
   const dispatch = useDispatch();
   const competitionID = useSelector((state: any) => state.game.competitionID);
-  const { data: groups, isLoading: isLoadingGroups } =
-    useGetGroupsWithPlayers(competitionID);
-  const { data: competition, isLoading: isLoadingCompetition } =
-    useGetCompetition(competitionID);
+  const { data: groups } = useGetGroupsWithPlayers(competitionID);
+  const { data: competition } = useGetCompetition(competitionID);
   const participantID = useSelector((state: any) => state.user.userId);
   const player = findPlayer(groups, participantID);
-  const { data: lane, isLoading: isLoadingLane } = useGetLaneWithPlayersScores(
-    player?.lane_id
-  );
+  const { data: lane } = useGetLaneWithPlayersScores(player?.lane_id ?? 0);
   const selectedPlayerID = useSelector(
     (state: any) => state.scoreController.selectedPlayerID
   );
 
-  if (
-    isLoadingGroups ||
-    isLoadingLane ||
-    isLoadingCompetition ||
-    player === undefined ||
-    lane === undefined
-  )
+  if (player === undefined || lane === undefined || competition === undefined)
     return <></>;
 
   const handleOnChange = (_event: any, newID: number) => {
@@ -79,7 +70,7 @@ export default function LaneBoard() {
   );
 }
 
-const findPlayer = (groups: any[], participantID: number) => {
+const findPlayer = (groups: Group[] | undefined, participantID: number) => {
   if (groups === undefined) return;
   for (let i = 0; i < groups.length; i++) {
     for (let j = 0; j < groups[i].players.length; j++) {

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/PlayerInfoBar/PlayerInfoBar.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/PlayerInfoBar/PlayerInfoBar.tsx
@@ -11,10 +11,10 @@ interface Props {
 
 export default function PlayerInfo({ player }: Props) {
   const competitionID = useSelector((state: any) => state.game.competitionID);
-  const { data: competition, isLoading } = useGetCompetition(competitionID);
-  const currentEnd = competition.qualification_current_end;
+  const { data: competition } = useGetCompetition(competitionID);
+  const currentEnd = competition?.qualification_current_end;
 
-  if (isLoading || player === undefined || !currentEnd) return <></>;
+  if (!player || !competition || !currentEnd) return <></>;
   const end = extractEnd(player, currentEnd);
   const scores = extractScores(end);
   const isConfirmed = end.is_confirmed;

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/PlayerInfoBar/PlayerInfoBar.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/PlayerInfoBar/PlayerInfoBar.tsx
@@ -4,9 +4,10 @@ import ScoreBar from "./ScoreBar";
 import { useSelector } from "react-redux";
 import useGetCompetition from "../../../../QueryHooks/useGetCompetition";
 import { extractEnd, extractScores } from "../util";
+import { Player } from "../../../../QueryHooks/types/Lane";
 
 interface Props {
-  player: any;
+  player: Player;
 }
 
 export default function PlayerInfo({ player }: Props) {

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/PlayerInfoBar/ScoreBlock.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/PlayerInfoBar/ScoreBlock.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Avatar } from "@mui/material";
 import { useScoreColor } from "../../../../util/useScoreColor.tsx";
 
 interface Props {
@@ -23,22 +23,17 @@ export default function ScoreBlock(props: Props) {
   }
 
   return (
-    <Box
+    <Avatar
       sx={{
-        display: "flex",
         backgroundColor: scoreColor.backgroundColor,
         color: scoreColor.textColor,
         width: "20px",
         height: "20px",
         fontSize: "13px",
         marginBottom: "12px",
-        borderRadius: "50%",
-        justifyContent: "center",
-        alignItems: "center",
-        textAlign: "center",
       }}
     >
       {content}
-    </Box>
+    </Avatar>
   );
 }

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/ScoreController/ControllButtonGroup.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/ScoreController/ControllButtonGroup.tsx
@@ -3,12 +3,12 @@ import { useMutation, useQueryClient } from "react-query";
 
 import axios from "axios";
 import { findUnfilledScoreInEnd } from "../util";
+import { Player, Round, RoundEnd } from "../../../../QueryHooks/types/Lane";
 
 interface Props {
-  participantEnd: any;
-  selectedPlayer: any;
-  end: any;
-  round: any;
+  selectedPlayer: Player;
+  end: RoundEnd;
+  round: Round;
   isConfirmed: boolean;
 }
 const putIsConfirmed = ({ roundEndID, isConfirmed }: any) => {
@@ -28,7 +28,6 @@ const putScoreDeleted = ({ selectedPlayerID, round, end, lastScore }: any) => {
 export default function ControllButtonGroup({
   end,
   isConfirmed,
-  participantEnd,
   round,
   selectedPlayer,
 }: Props) {
@@ -51,20 +50,27 @@ export default function ControllButtonGroup({
   });
   const lastScore = findUnfilledScoreInEnd(end);
   const handleConfirmation = (_event: any) => {
-    toggleConfirmation({ roundEndID: participantEnd.id, isConfirmed });
+    toggleConfirmation({ roundEndID: end.id, isConfirmed });
   };
   const handledelete = (_event: any) => {
     deleteScore({ selectedPlayerID: selectedPlayer.id, round, end, lastScore });
   };
 
   return (
-    <ButtonGroup className="controll_button_group" fullWidth variant="text">
+    <ButtonGroup
+      className="controll_button_group"
+      fullWidth
+      variant="text"
+      disabled={end?.is_confirmed}
+      disableElevation
+    >
       <Button
         className="confirm_button"
         id={isConfirmed ? "confirmed" : "unconfirmed"}
         onClick={handleConfirmation}
+        disableRipple={isConfirmed}
       >
-        {isConfirmed ? "取消確認" : "確認"}
+        {isConfirmed ? "已確認" : "確認"}
       </Button>
       <Button
         disabled={

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/ScoreController/ControllButtonGroup.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/ScoreController/ControllButtonGroup.tsx
@@ -1,5 +1,5 @@
 import { ButtonGroup, Button } from "@mui/material";
-import { useMutation, useQueryClient } from "react-query";
+import { QueryClient, useMutation, useQueryClient } from "react-query";
 
 import axios from "axios";
 import { findUnfilledScoreInEnd } from "../util";
@@ -42,15 +42,15 @@ export default function ControllButtonGroup({
   });
   const { mutate: deleteScore } = useMutation(putScoreDeleted, {
     onSuccess: () => {
-      queryClient.invalidateQueries([
-        "laneWithPlayersScores",
-        selectedPlayer.lane_id,
-      ]);
+      invalidateLaneWithPlayerScoresQuery(queryClient, selectedPlayer);
     },
   });
   const lastScore = findUnfilledScoreInEnd(end);
   const handleConfirmation = (_event: any) => {
-    toggleConfirmation({ roundEndID: end.id, isConfirmed });
+    if (end.is_confirmed)
+      invalidateLaneWithPlayerScoresQuery(queryClient, selectedPlayer);
+    else toggleConfirmation({ roundEndID: end.id, isConfirmed });
+    console.log("handleConfirmation");
   };
   const handledelete = (_event: any) => {
     deleteScore({ selectedPlayerID: selectedPlayer.id, round, end, lastScore });
@@ -61,7 +61,6 @@ export default function ControllButtonGroup({
       className="controll_button_group"
       fullWidth
       variant="text"
-      disabled={end?.is_confirmed}
       disableElevation
     >
       <Button
@@ -83,4 +82,13 @@ export default function ControllButtonGroup({
       </Button>
     </ButtonGroup>
   );
+}
+function invalidateLaneWithPlayerScoresQuery(
+  queryClient: QueryClient,
+  selectedPlayer: Player
+) {
+  queryClient.invalidateQueries([
+    "laneWithPlayersScores",
+    selectedPlayer.lane_id,
+  ]);
 }

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/ScoreController/ScoreController.tsx
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/ScoreController/ScoreController.tsx
@@ -17,8 +17,8 @@ export default function ScoreController({
   possibleScores,
 }: Props) {
   const competitionID = useSelector((state: any) => state.game.competitionID);
-  const { data: competition, isLoading } = useGetCompetition(competitionID);
-  if (isLoading) return <></>;
+  const { data: competition } = useGetCompetition(competitionID);
+  if (!competition) return <></>;
   console.log(player);
   const currentEnd = competition.qualification_current_end;
   const round = extractround(selectedPlayer, currentEnd);
@@ -26,6 +26,7 @@ export default function ScoreController({
   const participantEnd = extractEnd(player, currentEnd);
   let scoreButtons = [];
 
+  if (!round || !end || !participantEnd) return <></>;
   for (let i = 0; i < possibleScores.length; i++) {
     scoreButtons.push(
       <ScoreButton
@@ -49,11 +50,10 @@ export default function ScoreController({
         {scoreButtons}
       </ButtonGroup>
       <ControllButtonGroup
-        participantEnd={participantEnd}
         selectedPlayer={selectedPlayer}
         round={round}
         end={end}
-        isConfirmed={participantEnd?.is_confirmed}
+        isConfirmed={end?.is_confirmed ?? false}
       ></ControllButtonGroup>
     </>
   );

--- a/frontend_scoring/src/features/RecordingBoard/LaneBoard/util.ts
+++ b/frontend_scoring/src/features/RecordingBoard/LaneBoard/util.ts
@@ -1,4 +1,6 @@
-export const extractEnd = (player: any, currentEnd: number) => {
+import { Player, RoundEnd } from "../../../QueryHooks/types/Lane";
+
+export const extractEnd = (player: Player, currentEnd: number) => {
   if (player === undefined) return;
 
   const currentRound = Math.ceil(currentEnd / 6);
@@ -8,14 +10,14 @@ export const extractEnd = (player: any, currentEnd: number) => {
 
   return end;
 };
-export const extractround = (player: any, currentEnd: number) => {
+export const extractround = (player: Player, currentEnd: number) => {
   if (player === undefined) return;
   const currentRound = Math.ceil(currentEnd / 6);
   const round = player.rounds[currentRound - 1];
 
   return round;
 };
-export const extractScores = (end: any) => {
+export const extractScores = (end: RoundEnd) => {
   if (end === undefined) return [];
   let scores = [];
   for (let i = 0; i < end.round_scores.length; i++) {
@@ -24,14 +26,14 @@ export const extractScores = (end: any) => {
   return scores;
 };
 
-export const findLastScoreInEnd = (end: any) => {
+export const findLastScoreInEnd = (end: RoundEnd) => {
   if (end === undefined) return;
   for (let i = 0; i < end.round_scores.length; i++) {
     if (end.round_scores[i].score === -1) return end.round_scores[i];
   }
   return undefined;
 };
-export const findUnfilledScoreInEnd = (end: any) => {
+export const findUnfilledScoreInEnd = (end: RoundEnd) => {
   if (end === undefined) return;
   for (let i = 0; i < end.round_scores.length; i++) {
     if (end.round_scores[i].score === -1) return end.round_scores[i - 1];


### PR DESCRIPTION
- Disabled players to reverse their confirmation.
- Now players can confirm others' scores, but cannot reverse it.
- Now admins can toggle confirmation of scores for players.
- When admin toggled a player's confirmation status, the player can click the comfirmation to show the change, whitout refresh the page.

- Changed score block from Box to Avatar 
