### PR TITLE
K8s manifests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,18 @@
-version: "3.9"
+name: nycu-archery-system
 
 services:
   frontend-scoring:
-    build: ./frontend_scoring
+    build:
+      context: ./frontend_scoring
     restart: always
-    volumes:
-      - ./frontend_scoring:/app
-      - /app/node_modules
-      - /app/dist
   frontend-profile:
-    build: ./frontend_profile
+    build:
+      context: ./frontend_profile
     restart: always
-    volumes:
-      - ./frontend_profile:/app
-      - /app/node_modules
-      - /app/dist
   mysql:
     image: mysql:8
+    volumes:
+      - db_data:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: db
@@ -24,10 +20,12 @@ services:
       MYSQL_PASSWORD: password
     restart: always
   backend:
-    build: ./backend
+    build:
+      context: ./backend
     restart: always
   reverse-proxy:
-    build: ./reverse-proxy
+    build:
+      context: ./reverse-proxy
     restart: always
     ports:
       - 80:80
@@ -36,6 +34,8 @@ services:
       - frontend-scoring
       - frontend-profile
       - backend
+volumes:
+  db_data:
 #    volumes:
 #      - /certbot/www:/var/www/certbot/:ro
 #      - /certbot/conf/:/etc/nginx/ssl/:ro

--- a/manifests/backend-deployment.yaml
+++ b/manifests/backend-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert --build local
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: backend
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: backend
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert --build local
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: backend
+    spec:
+      containers:
+        - image: backend
+          name: backend
+          imagePullPolicy: Never
+      restartPolicy: Always

--- a/manifests/backend-service.yaml
+++ b/manifests/backend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    io.kompose.service: backend
+spec:
+  ports:
+    - port: 8080
+  selector:
+    io.kompose.service: backend

--- a/manifests/db-data-persistentvolumeclaim.yaml
+++ b/manifests/db-data-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: db-data
+  name: db-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/manifests/frontend-profile-deployment.yaml
+++ b/manifests/frontend-profile-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert --build local
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: frontend-profile
+  name: frontend-profile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: frontend-profile
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert --build local
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: frontend-profile
+    spec:
+      containers:
+        - image: frontend-profile
+          name: frontend-profile
+          imagePullPolicy: Never
+      restartPolicy: Always

--- a/manifests/frontend-profile-service.yaml
+++ b/manifests/frontend-profile-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-profile
+  labels:
+    io.kompose.service: frontend-profile
+spec:
+  ports:
+    - port: 3000
+  selector:
+    io.kompose.service: frontend-profile

--- a/manifests/frontend-scoring-deployment.yaml
+++ b/manifests/frontend-scoring-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert --build local
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: frontend-scoring
+  name: frontend-scoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: frontend-scoring
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert --build local
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: frontend-scoring
+    spec:
+      containers:
+        - image: frontend-scoring
+          name: frontend-scoring
+          imagePullPolicy: Never
+      restartPolicy: Always

--- a/manifests/frontend-scoring-service.yaml
+++ b/manifests/frontend-scoring-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-scoring
+  labels:
+    io.kompose.service: frontend-scoring
+spec:
+  ports:
+    - port: 3000
+  selector:
+    io.kompose.service: frontend-scoring

--- a/manifests/mysql-deployment.yaml
+++ b/manifests/mysql-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert --build local
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: mysql
+  name: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert --build local
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: mysql
+    spec:
+      containers:
+        - env:
+            - name: MYSQL_DATABASE
+              value: db
+            - name: MYSQL_PASSWORD
+              value: password
+            - name: MYSQL_ROOT_PASSWORD
+              value: root
+            - name: MYSQL_USER
+              value: user
+          image: mysql:8
+          name: mysql
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: db-data
+      restartPolicy: Always
+      volumes:
+        - name: db-data
+          persistentVolumeClaim:
+            claimName: db-data

--- a/manifests/mysql-service.yaml
+++ b/manifests/mysql-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    io.kompose.service: mysql
+spec:
+  ports:
+    - port: 3306
+  selector:
+    io.kompose.service: mysql

--- a/manifests/reverse-proxy-deployment.yaml
+++ b/manifests/reverse-proxy-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert --build local
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: reverse-proxy
+  name: reverse-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: reverse-proxy
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert --build local
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: reverse-proxy
+    spec:
+      containers:
+        - image: reverse-proxy
+          name: reverse-proxy
+          ports:
+            - containerPort: 80
+              protocol: TCP
+            - containerPort: 443
+              protocol: TCP
+          imagePullPolicy: Never
+      restartPolicy: Always

--- a/manifests/reverse-proxy-service.yaml
+++ b/manifests/reverse-proxy-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert --build local
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: reverse-proxy
+  name: reverse-proxy
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+    - name: "443"
+      port: 443
+      targetPort: 443
+  selector:
+    io.kompose.service: reverse-proxy


### PR DESCRIPTION
 用kompose創建了一些manifest，已經可以在本地動起來。加了操作方式在[wiki](https://github.com/NYCUarchery/archeryWebsite/wiki/K8s-manifests)，還更新了一下production的docker compose。