### PR TITLE
Set up for release

### DIFF
--- a/backend/internal/pkg/session.go
+++ b/backend/internal/pkg/session.go
@@ -54,6 +54,7 @@ func IsAuthenticated(c *gin.Context) bool {
 
 func SaveAuthSession(c *gin.Context, id uint, username string) {
 	session := sessions.Default(c)
+	session.Options(sessions.Options{Path: "/"})
 	session.Set("username", username)
 	session.Set("id", id)
 	session.Save()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-name: nycu-archery-system
+version: "3.8"
 
 services:
   frontend:
@@ -19,23 +19,37 @@ services:
     build:
       context: ./backend
     restart: unless-stopped
+    depends_on:
+      - mysql
   reverse-proxy:
     build:
       context: ./reverse-proxy
     restart: unless-stopped
+    volumes:
+      - /certbot/www:/var/www/certbot/:ro
+      - /certbot/conf/:/etc/nginx/ssl/:ro
     ports:
       - 80:80
       - 443:443
     depends_on:
       - frontend
       - backend
+      - certbot
+  certbot:
+    image: certbot/certbot:latest
+    volumes:
+      - /certbot/www/:/var/www/certbot/:rw
+      - /certbot/conf/:/etc/letsencrypt/:rw
+    entrypoint:
+    - /bin/sh
+    - -c
+    - |
+      trap exit TERM;
+      while :;
+      do
+        certbot renew;
+        sleep 12h;
+      done;
+
 volumes:
   db_data:
-#    volumes:
-#      - /certbot/www:/var/www/certbot/:ro
-#      - /certbot/conf/:/etc/nginx/ssl/:ro
-#  certbot:
-#    image: certbot/certbot:latest
-#    volumes:
-#      - /certbot/www/:/var/www/certbot/:rw
-#      - /certbot/conf/:/etc/letsencrypt/:rw

--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -5,7 +5,7 @@ http{
     server {
         listen 80;
         listen [::]:80;
-        server_name nycuarchery.lolainta.com;
+        server_name archery.club.nycu.edu.tw;
         location / {
             proxy_pass http://frontend:3000;
         }
@@ -23,16 +23,13 @@ http{
         # listen 443 default_server ssl http2;
         # listen [::]:443 ssl http2;
 
-        # server_name nycuarchery.lolainta.com;
+        # server_name archery.club.nycu.edu.tw;
 
-        # ssl_certificate /etc/nginx/ssl/live/nycuarchery.lolainta.com/fullchain.pem;
-        # ssl_certificate_key /etc/nginx/ssl/live/nycuarchery.lolainta.com/privkey.pem;
+        # ssl_certificate /etc/nginx/ssl/live/archery.club.nycu.edu.tw/fullchain.pem;
+        # ssl_certificate_key /etc/nginx/ssl/live/archery.club.nycu.edu.tw/privkey.pem;
 
         # location / {
-            # proxy_pass http://frontend-profile:3000;
-        # }
-        # location /scoring {
-            # proxy_pass http://frontend-scoring:3000;
+            # proxy_pass http://frontend:3000;
         # }
         # location /api {
             # proxy_pass http://backend:8080;


### PR DESCRIPTION
[feat: set production compose file to use https](https://github.com/NYCUarchery/archeryWebsite/commit/d2874afdd91a93e915ffe778fe308481303e1477)
把舊的設定喬一下，上次比賽有用https，等我申請到domain name我就會開始嘗試轉成https。
[feat: set session cookie path to "/"](https://github.com/NYCUarchery/archeryWebsite/commit/8a17a5f06b20c5ed3bc1c7cd44a3fd45e321529c)
因為不明原因，只要連線不是用localhost，cookie的path就會被設定成獲得該cookie的path，加了這個可以強制設定path為"/" （i.e. 全部路徑可用）。