### PR TITLE
fix: add path option when clearing session

### DIFF
--- a/backend/internal/pkg/session.go
+++ b/backend/internal/pkg/session.go
@@ -62,6 +62,7 @@ func SaveAuthSession(c *gin.Context, id uint, username string) {
 
 func ClearAuthSession(c *gin.Context) {
 	session := sessions.Default(c)
+	session.Options(sessions.Options{Path: "/"})
 	session.Clear()
 	session.Save()
 }


### PR DESCRIPTION
這個如果不加的話會無法登出，對應[feat: set session cookie path to "/"](https://github.com/NYCUarchery/archeryWebsite/commit/8a17a5f06b20c5ed3bc1c7cd44a3fd45e321529c)，創建session要強制設定path，看起來刪除時也要。
