### PR TITLE
fix: https settings for production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 1s    
-      timeout: 3s     
-      retries: 30     
-      start_period: 5s 
+      interval: 1s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
   backend:
     build:
       context: ./backend
@@ -32,31 +32,17 @@ services:
     build:
       context: ./reverse-proxy
     restart: unless-stopped
-    # volumes:
-    #   - /certbot/www:/var/www/certbot/:ro
-    #   - /certbot/conf/:/etc/nginx/ssl/:ro
+    volumes:
+      - ./reverse-proxy/nginx.conf:/etc/nginx/nginx.conf
+      - /etc/letsencrypt/live/archery.club.nycu.edu.tw-0001/:/etc/letsencrypt/live/archery.club.nycu.edu.tw/
+      - /etc/letsencrypt/archive:/etc/letsencrypt/archive
+
     ports:
       - 80:80
       - 443:443
     depends_on:
       - frontend
       - backend
-  #     - certbot
-  # certbot:
-  #   image: certbot/certbot:latest
-  #   volumes:
-  #     - /certbot/www/:/var/www/certbot/:rw
-  #     - /certbot/conf/:/etc/letsencrypt/:rw
-  #   entrypoint:
-  #     - /bin/sh
-  #     - -c
-  #     - |
-  #       trap exit TERM;
-  #       while :;
-  #       do
-  #         certbot renew;
-  #         sleep 12h;
-  #       done;
 
 volumes:
   db_data:

--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -20,26 +20,24 @@ http{
     }
 
     # server {
-        # listen 443 default_server ssl http2;
-        # listen [::]:443 ssl http2;
+    #     listen 443 ssl http2;
+    #     listen [::]:443 ssl http2;
+    #     server_name archery.club.nycu.edu.tw;
 
-        # server_name archery.club.nycu.edu.tw;
+    #     ssl_certificate /etc/letsencrypt/live/archery.club.nycu.edu.tw/fullchain.pem;
+    #     ssl_certificate_key /etc/letsencrypt/live/archery.club.nycu.edu.tw/privkey.pem;
 
-        # ssl_certificate /etc/nginx/ssl/live/archery.club.nycu.edu.tw/fullchain.pem;
-        # ssl_certificate_key /etc/nginx/ssl/live/archery.club.nycu.edu.tw/privkey.pem;
+    #     ssl_protocols TLSv1.2 TLSv1.3;
+    #     ssl_ciphers HIGH:!aNULL:!MD5;
 
-        # location / {
-            # proxy_pass http://frontend:3000;
-        # }
-        # location /api {
-            # proxy_pass http://backend:8080;
-        # }
-        # location /swagger {
-            # proxy_pass http://backend:8080;
-        # }
-        # location /.well-known/acme-challenge/ {
-            # root /var/www/certbot;
-        # }
-
+    #     location / {
+    #         proxy_pass http://frontend:3000;
+    #     }
+    #     location /api {
+    #         proxy_pass http://backend:80;
+    #     }
+    #     location /swagger {
+    #         proxy_pass http://backend:80;
+    #     }
     # }
 }


### PR DESCRIPTION
`nginx.conf` 有些設定在部屬的時候要解comment，這個跟憑證更新我之後要寫wiki。
先把certbot的container刪掉了，目前還不是很明白container的方案要怎麼work。