### PR TITLE
release 0.2.1.a fix: false login prompt in recent competitions page when logged in

### DIFF
--- a/frontend/src/app/(home)/recent_competitions/page.tsx
+++ b/frontend/src/app/(home)/recent_competitions/page.tsx
@@ -11,11 +11,13 @@ import { CompetitionList } from "@/components/CompetitionList";
 import { useQuery } from "react-query";
 import { apiClient } from "@/utils/ApiClient";
 import { DatabaseCompetition } from "@/types/Api";
+import { useGetUserId } from "@/utils/QueryHooks/useGetUserID";
 
 export default function RecentCompetitionPage() {
   const [page, setPage] = useState(1);
   const [startIndex, setStartIndex] = useState((page - 1) * 5);
   const [endIndex, setEndIndex] = useState(page * 5 - 1);
+  const { data: uid } = useGetUserId();
 
   const { data: competitions, isLoading: isLoadingCompetitions } = useQuery(
     "competitions",
@@ -56,7 +58,7 @@ export default function RecentCompetitionPage() {
         {isLoadingCompetitions || !competitions ? (
           <p>loading...</p>
         ) : (
-          <CompetitionList competitions={competitions} />
+          <CompetitionList competitions={competitions} uid={uid} />
         )}
 
         <Pagination


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/745db367-f0d3-401f-94ce-31cfd16f1b95)
