### PR TITLE
feat: eagerly refresh scoring page

### DIFF
--- a/frontend/src/utils/QueryHooks/useGetCompetitionWithGroups.ts
+++ b/frontend/src/utils/QueryHooks/useGetCompetitionWithGroups.ts
@@ -6,7 +6,6 @@ export default function useGetCompetitionWithGroups(id: number) {
     () => apiClient.competition.groupsDetail(id),
     {
       select: (data) => data.data,
-      staleTime: 60000 * 30,
     }
   );
 }


### PR DESCRIPTION
Removed staleTime of the competition query in the scoring page.
Now the page is eagerly refreshed to prevent players from editing the old end when the endIndex has changed.

close #255 